### PR TITLE
fix(runtime): keep DNS responsive during upstream failures

### DIFF
--- a/internal/runtime/bootstrap_refresh_test.go
+++ b/internal/runtime/bootstrap_refresh_test.go
@@ -14,7 +14,7 @@ func TestBootstrapRefresherDedupesAndSwapsEndpoint(t *testing.T) {
 	release := make(chan struct{})
 	var calls atomic.Int32
 	old := resolveBootstrapIPsFunc
-	resolveBootstrapIPsFunc = func(string) ([]string, error) {
+	resolveBootstrapIPsFunc = func(context.Context, string) ([]string, error) {
 		calls.Add(1)
 		<-release
 		return []string{"9.9.9.9"}, nil
@@ -24,7 +24,7 @@ func TestBootstrapRefresherDedupesAndSwapsEndpoint(t *testing.T) {
 	var ptr atomic.Pointer[endpoint.DOHEndpoint]
 	ptr.Store(&endpoint.DOHEndpoint{Hostname: "h", Path: "/p", Bootstrap: []string{"1.1.1.1"}})
 	rec := &recordingEndpoint{}
-	mgr := newEndpointManager(endpoint.StaticProvider([]endpoint.Endpoint{rec}), rec)
+	mgr := newEndpointManager(rec, endpoint.StaticProvider([]endpoint.Endpoint{rec}))
 	r := &bootstrapRefresher{hostname: "h", path: "/p", ep: &ptr, mgr: mgr}
 
 	r.refresh(context.Background())
@@ -40,5 +40,35 @@ func TestBootstrapRefresherDedupesAndSwapsEndpoint(t *testing.T) {
 	}
 	if got := ptr.Load().Bootstrap; !slices.Equal(got, []string{"9.9.9.9"}) {
 		t.Fatalf("bootstrap = %v, want swapped to [9.9.9.9]", got)
+	}
+}
+
+func TestBootstrapRefresherCancellationPreservesEndpoint(t *testing.T) {
+	started := make(chan struct{})
+	old := resolveBootstrapIPsFunc
+	resolveBootstrapIPsFunc = func(ctx context.Context, _ string) ([]string, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	t.Cleanup(func() { resolveBootstrapIPsFunc = old })
+	var ptr atomic.Pointer[endpoint.DOHEndpoint]
+	original := &endpoint.DOHEndpoint{Hostname: "h", Bootstrap: []string{"1.1.1.1"}}
+	ptr.Store(original)
+	r := &bootstrapRefresher{hostname: "h", ep: &ptr}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r.refresh(ctx)
+	<-started
+	cancel()
+	deadline := time.Now().Add(time.Second)
+	for r.busy.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if r.busy.Load() {
+		t.Fatal("canceled refresh is still running")
+	}
+	if ptr.Load() != original {
+		t.Fatal("canceled refresh replaced the current endpoint")
 	}
 }

--- a/internal/runtime/dns_bootstrap.go
+++ b/internal/runtime/dns_bootstrap.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
+	"os/exec"
+	"runtime"
 	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
 
-	"github.com/nextdns/nextdns/host"
 	"github.com/nextdns/nextdns/resolver/endpoint"
 	"github.com/ugzv/ublockdnsclient/internal/core"
 )
@@ -25,44 +27,102 @@ var bootstrapResolvers = []string{
 // resolveBootstrapIPs resolves a hostname via public resolvers (UDP/TCP),
 // bypassing the system resolver. This prevents a circular dependency when
 // system DNS is pointed at 127.0.0.1 (i.e., at this proxy).
-func resolveBootstrapIPs(hostname string) ([]string, error) {
-	seen := map[string]struct{}{}
-	var out []string
-	var errs []string
-
-	for _, server := range bootstrapResolvers {
-		for _, network := range []string{"udp", "tcp"} {
-			addrs, err := lookupHostVia(server, network, hostname)
-			if err != nil {
-				errs = append(errs, fmt.Sprintf("%s/%s: %v", server, network, err))
-				continue
-			}
-			for _, addr := range addrs {
-				out = core.AppendUniqueString(out, seen, addr)
-			}
-		}
-	}
-
-	// Fallback for locked-down networks that block direct DNS to public resolvers.
-	// Only use system DNS if it's not already pointed to this local proxy.
-	if len(out) == 0 && !core.HasLocalDNS(host.DNS()) {
-		addrs, err := lookupHostSystem(hostname)
-		if err != nil {
-			errs = append(errs, fmt.Sprintf("system resolver: %v", err))
-		} else {
-			for _, addr := range addrs {
-				out = core.AppendUniqueString(out, seen, addr)
-			}
-		}
-	}
-
-	if len(out) == 0 {
-		return nil, fmt.Errorf("bootstrap resolution failed for %s (%s)", hostname, strings.Join(errs, "; "))
-	}
-	return out, nil
+func resolveBootstrapIPs(ctx context.Context, hostname string) ([]string, error) {
+	return (bootstrapLookup{lookupHostVia, discoverDNSServers}).resolve(ctx, hostname)
 }
 
-func lookupHostVia(serverAddr, transport, hostname string) ([]string, error) {
+type bootstrapLookup struct {
+	via       func(context.Context, string, string, string) ([]string, error)
+	systemDNS func(context.Context) []string
+}
+
+func (l bootstrapLookup) resolve(ctx context.Context, hostname string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	// Reserve half the total budget for system DNS on networks blocking public DNS.
+	deadline, _ := ctx.Deadline()
+	publicCtx, cancelPublic := context.WithTimeout(ctx, time.Until(deadline)/2)
+	defer cancelPublic()
+	ips, err := l.lookup(publicCtx, bootstrapResolvers, hostname)
+	cancelPublic()
+	if err == nil {
+		return ips, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	// Query discovered DNS servers explicitly. The system resolver may already
+	// point to this proxy even when DHCP advertises a non-local DNS server.
+	var servers []string
+	for _, entry := range l.systemDNS(ctx) {
+		for _, addr := range strings.Fields(entry) {
+			if ip := net.ParseIP(addr); ip != nil && !ip.IsLoopback() && !ip.IsUnspecified() {
+				servers = append(servers, net.JoinHostPort(addr, "53"))
+			}
+		}
+	}
+	if len(servers) > 0 {
+		return l.lookup(ctx, servers, hostname)
+	}
+	return nil, err
+}
+
+// lookup returns the first usable answer and cancels all remaining exchanges.
+func (l bootstrapLookup) lookup(ctx context.Context, servers []string, hostname string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	type result struct {
+		addrs []string
+		err   error
+	}
+	count := len(servers) * 2
+	results := make(chan result, count)
+	for _, server := range servers {
+		for _, network := range []string{"udp", "tcp"} {
+			go func() {
+				addrs, err := l.via(ctx, server, network, hostname)
+				if err != nil {
+					err = fmt.Errorf("%s/%s: %w", server, network, err)
+				}
+				results <- result{addrs, err}
+			}()
+		}
+	}
+	var errs []string
+	for range count {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case r := <-results:
+			if r.err != nil {
+				errs = append(errs, r.err.Error())
+				continue
+			}
+			seen := map[string]struct{}{}
+			var ips []string
+			for _, addr := range r.addrs {
+				if net.ParseIP(addr) != nil {
+					ips = core.AppendUniqueString(ips, seen, addr)
+				}
+			}
+			if len(ips) > 0 {
+				return ips, nil
+			}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, fmt.Errorf("bootstrap resolution failed for %s (%s)", hostname, strings.Join(errs, "; "))
+}
+
+func lookupHostVia(ctx context.Context, serverAddr, transport, hostname string) ([]string, error) {
 	r := &net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
@@ -70,9 +130,6 @@ func lookupHostVia(serverAddr, transport, hostname string) ([]string, error) {
 			return d.DialContext(ctx, transport, serverAddr)
 		},
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	addrs, err := r.LookupHost(ctx, hostname)
 	if err != nil {
@@ -84,18 +141,74 @@ func lookupHostVia(serverAddr, transport, hostname string) ([]string, error) {
 	return addrs, nil
 }
 
-func lookupHostSystem(hostname string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+// discoverDNSServers obtains network DNS without going through the local proxy.
+// External platform commands share a short, cancellable discovery budget.
+func discoverDNSServers(ctx context.Context) []string {
+	return discoverDNSServersWith(ctx, runtime.GOOS, func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		cmd := exec.CommandContext(ctx, name, args...)
+		cmd.WaitDelay = 100 * time.Millisecond
+		return cmd.Output()
+	}, os.ReadFile)
+}
 
-	addrs, err := net.DefaultResolver.LookupHost(ctx, hostname)
-	if err != nil {
-		return nil, err
+func discoverDNSServersWith(ctx context.Context, platform string, command func(context.Context, string, ...string) ([]byte, error), readFile func(string) ([]byte, error)) []string {
+	budget := time.Second
+	if platform == "windows" {
+		budget = 3 * time.Second
 	}
-	if len(addrs) == 0 {
-		return nil, fmt.Errorf("no addresses found for %s", hostname)
+	ctx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+	if ctx.Err() != nil {
+		return nil
 	}
-	return addrs, nil
+	var entries []string
+	switch platform {
+	case "windows":
+		if b, err := command(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command",
+			`Get-DnsClientServerAddress | ForEach-Object { $_.ServerAddresses } | Where-Object { $_ }`); err == nil {
+			entries = strings.Fields(string(b))
+		}
+	case "darwin":
+		if b, err := command(ctx, "ipconfig", "getoption", "", "domain_name_server"); err == nil {
+			entries = strings.Fields(string(b))
+		}
+	case "linux":
+		if b, err := command(ctx, "nmcli", "dev", "show"); err == nil {
+			for line := range strings.SplitSeq(string(b), "\n") {
+				if strings.HasPrefix(line, "IP4.DNS") || strings.HasPrefix(line, "IP6.DNS") {
+					_, value, _ := strings.Cut(line, ":")
+					entries = append(entries, strings.Fields(value)...)
+				}
+			}
+		}
+		fallthrough
+	case "freebsd", "openbsd", "netbsd", "dragonfly":
+		for _, path := range []string{"/run/systemd/resolve/resolv.conf", "/etc/resolv.conf"} {
+			if ctx.Err() != nil {
+				break
+			}
+			if b, err := readFile(path); err == nil {
+				for line := range strings.SplitSeq(string(b), "\n") {
+					fields := strings.Fields(line)
+					if len(fields) >= 2 && fields[0] == "nameserver" {
+						entries = append(entries, fields[1])
+					}
+				}
+			}
+		}
+	}
+	seen := map[string]struct{}{}
+	var servers []string
+	for _, entry := range entries {
+		if ip := net.ParseIP(entry); ip != nil && !ip.IsLoopback() && !ip.IsUnspecified() {
+			servers = core.AppendUniqueString(servers, seen, ip.String())
+		}
+	}
+	return servers
+}
+
+type endpointTester interface {
+	Test(context.Context) error
 }
 
 var resolveBootstrapIPsFunc = resolveBootstrapIPs
@@ -106,7 +219,7 @@ var resolveBootstrapIPsFunc = resolveBootstrapIPs
 type bootstrapRefresher struct {
 	hostname, path string
 	ep             *atomic.Pointer[endpoint.DOHEndpoint]
-	mgr            *endpoint.Manager
+	mgr            endpointTester
 	busy           atomic.Bool
 }
 
@@ -116,8 +229,8 @@ func (b *bootstrapRefresher) refresh(ctx context.Context) {
 	}
 	go func() {
 		defer b.busy.Store(false)
-		ips, err := resolveBootstrapIPsFunc(b.hostname)
-		if err != nil || slices.Equal(ips, b.ep.Load().Bootstrap) {
+		ips, err := resolveBootstrapIPsFunc(ctx, b.hostname)
+		if err != nil || ctx.Err() != nil || slices.Equal(ips, b.ep.Load().Bootstrap) {
 			return
 		}
 		log.Printf("Bootstrap IPs changed for %s: %v", b.hostname, ips)
@@ -130,7 +243,7 @@ func (b *bootstrapRefresher) refresh(ctx context.Context) {
 	}()
 }
 
-func testEndpoints(ctx context.Context, mgr *endpoint.Manager, reason string) {
+func testEndpoints(ctx context.Context, mgr endpointTester, reason string) {
 	if err := mgr.Test(ctx); err != nil {
 		log.Printf("Endpoint test after %s failed: %v", reason, err)
 	}

--- a/internal/runtime/dns_bootstrap_test.go
+++ b/internal/runtime/dns_bootstrap_test.go
@@ -1,0 +1,193 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"net"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBootstrapReturnsFirstAnswerAndCancelsOtherLookups(t *testing.T) {
+	var running sync.WaitGroup
+	var calls atomic.Int32
+	allStarted := make(chan struct{})
+	lookup := bootstrapLookup{
+		via: func(ctx context.Context, server, transport, hostname string) ([]string, error) {
+			running.Add(1)
+			defer running.Done()
+			if calls.Add(1) == int32(len(bootstrapResolvers)*2) {
+				close(allStarted)
+			}
+			if server == bootstrapResolvers[1] && transport == "tcp" {
+				<-allStarted
+				return []string{"203.0.113.1", "203.0.113.1", "2001:db8::1"}, nil
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		systemDNS: func(context.Context) []string { return []string{"127.0.0.1"} },
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ips, err := lookup.resolve(ctx, "example.org")
+	if err != nil || !slices.Equal(ips, []string{"203.0.113.1", "2001:db8::1"}) {
+		t.Fatalf("resolve = %v, %v", ips, err)
+	}
+	done := make(chan struct{})
+	go func() { running.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("losing lookups were not canceled")
+	}
+}
+
+func TestBootstrapHonorsCallerCancellation(t *testing.T) {
+	started := make(chan struct{}, len(bootstrapResolvers)*2)
+	lookup := bootstrapLookup{
+		via: func(ctx context.Context, _, _, _ string) ([]string, error) {
+			started <- struct{}{}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		systemDNS: func(context.Context) []string { return []string{"127.0.0.1"} },
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { _, err := lookup.resolve(ctx, "example.org"); done <- err }()
+	<-started
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("bootstrap ignored caller cancellation")
+	}
+}
+
+func TestBootstrapSystemFallbackAvoidsLocalDNS(t *testing.T) {
+	for _, dns := range []string{"127.0.0.1", "::1", "192.0.2.53"} {
+		t.Run(dns, func(t *testing.T) {
+			var calls atomic.Int32
+			lookup := bootstrapLookup{
+				via: func(_ context.Context, server, _, _ string) ([]string, error) {
+					if server == "192.0.2.53:53" {
+						calls.Add(1)
+						return []string{"203.0.113.2"}, nil
+					}
+					return nil, errors.New("public DNS unavailable")
+				},
+				systemDNS: func(context.Context) []string { return []string{dns} },
+			}
+			ips, err := lookup.resolve(context.Background(), "example.org")
+			if net.ParseIP(dns).IsLoopback() {
+				if err == nil || calls.Load() != 0 {
+					t.Fatalf("local DNS fallback: ips=%v err=%v calls=%d", ips, err, calls.Load())
+				}
+			} else if err != nil || calls.Load() == 0 || !slices.Equal(ips, []string{"203.0.113.2"}) {
+				t.Fatalf("system fallback: ips=%v err=%v calls=%d", ips, err, calls.Load())
+			}
+		})
+	}
+}
+
+func TestBootstrapSharesDeadlineWithSystemFallback(t *testing.T) {
+	var systemCalled atomic.Bool
+	lookup := bootstrapLookup{
+		via: func(ctx context.Context, server, _, _ string) ([]string, error) {
+			if server == "192.0.2.53:53" {
+				systemCalled.Store(true)
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		systemDNS: func(context.Context) []string { return []string{"192.0.2.53"} },
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := lookup.resolve(ctx, "example.org")
+	if !errors.Is(err, context.DeadlineExceeded) || !systemCalled.Load() {
+		t.Fatalf("error = %v, system called = %v", err, systemCalled.Load())
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("deadline exceeded: %s", elapsed)
+	}
+}
+
+func TestDiscoverDNSServersCancelsPlatformCommand(t *testing.T) {
+	started := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan []string, 1)
+	go func() {
+		done <- discoverDNSServersWith(ctx, "darwin", func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}, nil)
+	}()
+	<-started
+	cancel()
+	select {
+	case servers := <-done:
+		if len(servers) != 0 {
+			t.Fatalf("servers = %v, want none after cancellation", servers)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("discovery did not propagate cancellation")
+	}
+}
+
+func TestDiscoverDNSServersFiltersAndDeduplicates(t *testing.T) {
+	for _, platform := range []string{"darwin", "linux", "windows"} {
+		t.Run(platform, func(t *testing.T) {
+			servers := discoverDNSServersWith(context.Background(), platform, func(_ context.Context, name string, args ...string) ([]byte, error) {
+				if platform == "windows" {
+					if name != "powershell" || !slices.Equal(args, []string{"-NoProfile", "-NonInteractive", "-Command", `Get-DnsClientServerAddress | ForEach-Object { $_.ServerAddresses } | Where-Object { $_ }`}) {
+						t.Fatalf("unexpected Windows discovery command: %s %v", name, args)
+					}
+					return []byte("127.0.0.1\r\n192.0.2.53\r\n2001:db8::53\r\n192.0.2.53\r\n::1\r\n0.0.0.0\r\ninvalid\r\n"), nil
+				}
+				if platform == "darwin" {
+					return []byte("127.0.0.1 192.0.2.53 2001:db8::53 192.0.2.53 ::1 0.0.0.0 invalid"), nil
+				}
+				return []byte("IP4.DNS[1]: 192.0.2.53\nIP6.DNS[1]: 2001:db8::53\nIP4.ADDRESS[1]: 192.0.2.10"), nil
+			}, func(string) ([]byte, error) {
+				return []byte("nameserver 127.0.0.1\nnameserver 192.0.2.53\n# nameserver 203.0.113.1\nnameserver ::1"), nil
+			})
+			if !slices.Equal(servers, []string{"192.0.2.53", "2001:db8::53"}) {
+				t.Fatalf("servers = %v", servers)
+			}
+		})
+	}
+}
+
+func TestWindowsDNSDiscoveryPreservesParentDeadline(t *testing.T) {
+	for _, budget := range []time.Duration{250 * time.Millisecond, 10 * time.Second} {
+		t.Run(budget.String(), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), budget)
+			defer cancel()
+			called := false
+			discoverDNSServersWith(ctx, "windows", func(commandCtx context.Context, _ string, _ ...string) ([]byte, error) {
+				called = true
+				deadline, ok := commandCtx.Deadline()
+				remaining := time.Until(deadline)
+				want := min(budget, 3*time.Second)
+				if !ok || remaining > want || remaining < want-100*time.Millisecond {
+					t.Fatalf("command deadline remaining = %v, want near %v", remaining, want)
+				}
+				return nil, nil
+			}, nil)
+			if !called {
+				t.Fatal("Windows discovery command was not called")
+			}
+		})
+	}
+}

--- a/internal/runtime/endpoint_fallback.go
+++ b/internal/runtime/endpoint_fallback.go
@@ -2,71 +2,216 @@ package runtime
 
 import (
 	"context"
+	"encoding/binary"
+	"errors"
 	"fmt"
+	"log"
 	"net"
+	"sync"
+	"sync/atomic"
 	"time"
 
-	"github.com/nextdns/nextdns/host"
 	"github.com/nextdns/nextdns/resolver/endpoint"
-
 	"github.com/ugzv/ublockdnsclient/internal/core"
 )
 
 const dohProbeDomain = core.ProbeDomain
+const endpointProbeTimeout = time.Second
 
-var fallbackDNSServers = []string{
-	"1.1.1.1:53",
-	"8.8.8.8:53",
-	"9.9.9.9:53",
+var fallbackDNSServers = []string{"1.1.1.1:53", "8.8.8.8:53", "9.9.9.9:53"}
+
+type endpointSelection struct{ endpoint.Endpoint }
+type endpointTest struct {
+	done chan struct{}
+	err  error
 }
 
-func newEndpointManager(dohProvider endpoint.Provider, initEndpoint endpoint.Endpoint) *endpoint.Manager {
-	m := &endpoint.Manager{
-		Providers: []endpoint.Provider{
-			dohProvider,
-			endpoint.ProviderFunc(func(ctx context.Context) ([]endpoint.Endpoint, error) {
-				eps := fallbackDNSEndpoints()
-				return eps, nil
-			}),
-		},
-		InitEndpoint: initEndpoint,
-		// Re-test on the first failed query instead of the library default of
-		// 10, so a dead connection after wake/network change fails over fast.
-		ErrorThreshold: 1,
-	}
+// The library manager holds its query lock while testing endpoints. Keep its
+// tests entirely local; network probes publish a selection only after finishing.
+type endpointManager struct {
+	queries   *endpoint.Manager
+	providers []endpoint.Provider
+	selected  atomic.Pointer[endpointSelection]
+	mu        sync.Mutex
+	testing   *endpointTest
+}
 
-	// Override the upstream library probe domain so startup checks do not emit
-	// provider-branded verification lookups on first use.
-	m.EndpointTester = func(e endpoint.Endpoint) endpoint.Tester {
-		if e.Protocol() == endpoint.ProtocolDOH {
-			return func(ctx context.Context, _ string) error {
-				return testEndpointDomain(ctx, e, dohProbeDomain)
-			}
-		}
-		if e.Protocol() == endpoint.ProtocolDNS {
-			return func(ctx context.Context, testDomain string) error { return nil }
-		}
-		return nil
+func newEndpointManager(initial endpoint.Endpoint, providers ...endpoint.Provider) *endpointManager {
+	m := &endpointManager{providers: providers}
+	m.selected.Store(&endpointSelection{initial})
+	m.queries = &endpoint.Manager{
+		InitEndpoint: initial,
+		Providers: []endpoint.Provider{endpoint.ProviderFunc(func(context.Context) ([]endpoint.Endpoint, error) {
+			return []endpoint.Endpoint{m.selected.Load().Endpoint}, nil
+		})},
+		EndpointTester: func(endpoint.Endpoint) endpoint.Tester {
+			return func(context.Context, string) error { return nil }
+		},
 	}
-	m.GetMinTestInterval = func(e endpoint.Endpoint) time.Duration {
-		if e.Protocol() == endpoint.ProtocolDNS {
-			return 5 * time.Second
-		}
-		return 0
-	}
+	// Initialize the dependency's endpoint metadata before the first external
+	// probe can initialize its transport concurrently with a query.
+	_ = m.queries.Test(context.Background())
 	return m
 }
 
-func fallbackDNSEndpoints() []endpoint.Endpoint {
-	seen := map[string]struct{}{}
-	out := make([]endpoint.Endpoint, 0, len(host.DNS())+len(fallbackDNSServers))
-
-	// Prefer currently configured non-loopback system resolvers.
-	for _, ip := range host.DNS() {
-		parsed := net.ParseIP(ip)
-		if parsed == nil || parsed.IsLoopback() {
+// Test coalesces concurrent recovery requests and never holds the query lock
+// during I/O. Unavailable candidates leave the last selected endpoint intact.
+func (m *endpointManager) Test(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	if run := m.testing; run != nil {
+		m.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-run.done:
+			return run.err
+		}
+	}
+	run := &endpointTest{done: make(chan struct{})}
+	m.testing = run
+	m.mu.Unlock()
+	defer func() { m.mu.Lock(); close(run.done); m.testing = nil; m.mu.Unlock() }()
+	ctx, cancel := context.WithTimeout(ctx, 2*endpointProbeTimeout)
+	defer cancel()
+	for _, provider := range m.providers {
+		candidates, err := provider.GetEndpoints(ctx)
+		if err != nil {
+			run.err = err
 			continue
 		}
+		chosen, err := m.probe(ctx, candidates)
+		if err != nil {
+			run.err = err
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			run.err = err
+			return err
+		}
+		previous := m.selected.Swap(&endpointSelection{chosen})
+		if previous.Protocol() != chosen.Protocol() {
+			if chosen.Protocol() == endpoint.ProtocolDNS {
+				log.Printf("DNS recovery: using plaintext fallback; profile filtering is bypassed")
+			} else {
+				log.Printf("DNS recovery: restored encrypted profile resolver")
+			}
+		}
+		run.err = m.queries.Test(ctx) // No network operations in this manager.
+		return run.err
+	}
+	if run.err == nil {
+		run.err = errors.New("no reachable DNS endpoints")
+	}
+	return run.err
+}
+
+func (m *endpointManager) probe(ctx context.Context, candidates []endpoint.Endpoint) (endpoint.Endpoint, error) {
+	ctx, cancel := context.WithTimeout(ctx, endpointProbeTimeout)
+	defer cancel()
+	type result struct {
+		ep  endpoint.Endpoint
+		err error
+	}
+	results := make(chan result, len(candidates))
+	for _, ep := range candidates {
+		go func() {
+			results <- result{ep, testEndpointDomain(ctx, ep, dohProbeDomain)}
+		}()
+	}
+	var lastErr error
+	for range candidates {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case r := <-results:
+			if r.err == nil {
+				return r.ep, nil
+			}
+			lastErr = r.err
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no DNS endpoints")
+	}
+	return nil, lastErr
+}
+
+// While using a fallback, periodically try the preferred encrypted endpoint.
+func (m *endpointManager) watch(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if m.selected.Load().Protocol() == endpoint.ProtocolDNS {
+				_ = m.Test(ctx)
+			}
+		}
+	}
+}
+
+type fallbackDNSProvider struct {
+	windows    bool
+	discover   func(context.Context) []string
+	mu         sync.Mutex
+	servers    []string
+	refreshing bool
+}
+
+func newFallbackDNSProvider(platform string, discover func(context.Context) []string) *fallbackDNSProvider {
+	p := &fallbackDNSProvider{windows: platform == "windows", discover: discover}
+	if p.windows {
+		// PowerShell startup can exceed the recovery budget. Prime its cache
+		// before serving DNS, then keep discovery off the recovery path.
+		p.refresh()
+	}
+	return p
+}
+
+func (p *fallbackDNSProvider) String() string { return "fallback DNS" }
+
+func (p *fallbackDNSProvider) GetEndpoints(ctx context.Context) ([]endpoint.Endpoint, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !p.windows {
+		discoveryCtx, cancel := context.WithTimeout(ctx, endpointProbeTimeout/4)
+		defer cancel()
+		return fallbackEndpointsFor(p.discover(discoveryCtx)), nil
+	}
+	p.mu.Lock()
+	servers := p.servers
+	if !p.refreshing {
+		p.refreshing = true
+		go p.refresh()
+	}
+	p.mu.Unlock()
+	return fallbackEndpointsFor(servers), nil
+}
+
+func (p *fallbackDNSProvider) refresh() {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	servers := p.discover(ctx)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(servers) > 0 {
+		p.servers = servers
+	}
+	p.refreshing = false
+}
+
+func fallbackEndpointsFor(servers []string) []endpoint.Endpoint {
+	seen := map[string]struct{}{}
+	out := make([]endpoint.Endpoint, 0, len(servers)+len(fallbackDNSServers))
+
+	// Include the network's own resolvers as well as the public fallbacks.
+	for _, ip := range servers {
 		addr := net.JoinHostPort(ip, "53")
 		if _, ok := seen[addr]; ok {
 			continue
@@ -88,12 +233,38 @@ func fallbackDNSEndpoints() []endpoint.Endpoint {
 }
 
 func testEndpointDomain(ctx context.Context, e endpoint.Endpoint, hostname string) error {
-	queryID := uint16(0x4D21)
-	_, err := core.ExchangeDNSQuery(queryID, hostname, func(payload, buf []byte) (int, error) {
+	const queryID = uint16(0x4D21)
+	response, err := core.ExchangeDNSQuery(queryID, hostname, func(payload, buf []byte) (int, error) {
+		if dns, ok := e.(*endpoint.DNSEndpoint); ok {
+			// DNSEndpoint.Exchange in the pinned dependency mutates the transaction ID
+			// and compares its low byte against the response buffer before reading it.
+			// Use a connected UDP socket so the probe actually verifies this resolver.
+			conn, err := (&net.Dialer{}).DialContext(ctx, "udp", dns.Addr)
+			if err != nil {
+				return 0, err
+			}
+			defer conn.Close()
+			stop := context.AfterFunc(ctx, func() { _ = conn.Close() })
+			defer stop()
+			if deadline, ok := ctx.Deadline(); ok {
+				_ = conn.SetDeadline(deadline)
+			}
+			if _, err = conn.Write(payload); err != nil {
+				return 0, err
+			}
+			return conn.Read(buf)
+		}
 		return e.Exchange(ctx, payload, buf)
 	})
 	if err != nil {
-		return fmt.Errorf("endpoint probe failed for %q: %w", hostname, err)
+		return fmt.Errorf("endpoint probe failed: %w", err)
+	}
+	if len(response) < 12 || response[2]&0x80 == 0 {
+		return errors.New("endpoint probe returned an invalid DNS response")
+	}
+	rcode := binary.BigEndian.Uint16(response[2:4]) & 15
+	if rcode != 0 && rcode != 3 {
+		return fmt.Errorf("endpoint probe returned DNS rcode=%d", rcode)
 	}
 	return nil
 }

--- a/internal/runtime/endpoint_probe_test.go
+++ b/internal/runtime/endpoint_probe_test.go
@@ -20,19 +20,16 @@ func (e *recordingEndpoint) Equal(other endpoint.Endpoint) bool { return e == ot
 func (e *recordingEndpoint) Exchange(_ context.Context, payload, buf []byte) (int, error) {
 	e.lastQuery = append([]byte(nil), payload...)
 	copy(buf, payload)
+	buf[2] |= 0x80
 	return len(payload), nil
 }
 
 func TestEndpointTesterOverridesProbeDomain(t *testing.T) {
 	e := &recordingEndpoint{}
-	mgr := newEndpointManager(endpoint.StaticProvider([]endpoint.Endpoint{e}), e)
+	mgr := newEndpointManager(e, endpoint.StaticProvider([]endpoint.Endpoint{e}))
 
-	tester := mgr.EndpointTester(e)
-	if tester == nil {
-		t.Fatal("expected DoH endpoint tester")
-	}
-	if err := tester(context.Background(), "probe-test.dns.nextdns.io."); err != nil {
-		t.Fatalf("tester returned error: %v", err)
+	if err := mgr.Test(context.Background()); err != nil {
+		t.Fatalf("endpoint test returned error: %v", err)
 	}
 	if len(e.lastQuery) == 0 {
 		t.Fatal("expected query to be recorded")

--- a/internal/runtime/endpoint_recovery_test.go
+++ b/internal/runtime/endpoint_recovery_test.go
@@ -1,0 +1,122 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nextdns/nextdns/resolver/endpoint"
+)
+
+type probeEndpoint struct {
+	probe func(context.Context, []byte, []byte) (int, error)
+}
+
+func (e *probeEndpoint) String() string                     { return "test-doh" }
+func (e *probeEndpoint) Protocol() endpoint.Protocol        { return endpoint.ProtocolDOH }
+func (e *probeEndpoint) Equal(other endpoint.Endpoint) bool { return e == other }
+func (e *probeEndpoint) Exchange(ctx context.Context, q, buf []byte) (int, error) {
+	return e.probe(ctx, q, buf)
+}
+
+func TestEndpointProbeDoesNotBlockQueries(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	var once sync.Once
+	ep := &probeEndpoint{probe: func(ctx context.Context, q, buf []byte) (int, error) {
+		once.Do(func() { close(entered) })
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+		n := copy(buf, q)
+		buf[2] |= 0x80
+		return n, nil
+	}}
+	m := newEndpointManager(ep, endpoint.StaticProvider([]endpoint.Endpoint{ep}))
+	probeDone := make(chan error, 1)
+	go func() { probeDone <- m.Test(context.Background()) }()
+	<-entered
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- m.queries.Do(ctx, func(endpoint.Endpoint) error { return ctx.Err() }) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("query blocked behind probe: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Error("query blocked behind unrelated endpoint probe")
+	}
+	close(release)
+	<-probeDone
+}
+
+func TestEndpointManagerSkipsDeadFallback(t *testing.T) {
+	dead, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dead.Close() // Blackhole: deliberately never answer.
+	live, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer live.Close()
+	go func() {
+		buf := make([]byte, 2048)
+		for {
+			n, addr, err := live.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			buf[2] |= 0x80
+			_, _ = live.WriteTo(buf[:n], addr)
+		}
+	}()
+	bad := &probeEndpoint{probe: func(context.Context, []byte, []byte) (int, error) { return 0, errors.New("DoH unreachable") }}
+	m := newEndpointManager(bad,
+		endpoint.StaticProvider([]endpoint.Endpoint{bad}),
+		endpoint.StaticProvider([]endpoint.Endpoint{&endpoint.DNSEndpoint{Addr: dead.LocalAddr().String()}, &endpoint.DNSEndpoint{Addr: live.LocalAddr().String()}}),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := m.Test(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.queries.Do(ctx, func(ep endpoint.Endpoint) error {
+		if ep.String() != live.LocalAddr().String() {
+			return errors.New("selected unreachable first fallback instead of responding server")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEndpointProbeRejectsInvalidAndFailedResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		flags byte
+		valid bool
+	}{
+		{"answer", 0x80, true}, {"nxdomain", 0x83, true}, {"servfail", 0x82, false}, {"refused", 0x85, false}, {"query echo", 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ep := &probeEndpoint{probe: func(_ context.Context, q, buf []byte) (int, error) {
+				n := copy(buf, q)
+				buf[2] = tc.flags & 0x80
+				buf[3] = tc.flags & 15
+				return n, nil
+			}}
+			err := testEndpointDomain(context.Background(), ep, dohProbeDomain)
+			if (err == nil) != tc.valid {
+				t.Fatalf("probe err=%v valid=%v", err, tc.valid)
+			}
+		})
+	}
+}

--- a/internal/runtime/fallback_provider_test.go
+++ b/internal/runtime/fallback_provider_test.go
@@ -1,0 +1,114 @@
+package runtime
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nextdns/nextdns/resolver/endpoint"
+)
+
+func hasFallbackAddress(endpoints []endpoint.Endpoint, address string) bool {
+	for _, ep := range endpoints {
+		if ep.String() == address {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWindowsFallbackCachesSlowDiscoveryAndRefreshesWithoutBlocking(t *testing.T) {
+	var calls atomic.Int32
+	refreshStarted := make(chan struct{})
+	release := make(chan struct{})
+	provider := newFallbackDNSProvider("windows", func(ctx context.Context) []string {
+		if calls.Add(1) == 1 {
+			select {
+			case <-time.After(300 * time.Millisecond):
+				return []string{"192.0.2.53"}
+			case <-ctx.Done():
+				return nil
+			}
+		}
+		close(refreshStarted)
+		select {
+		case <-release:
+			return []string{"192.0.2.54"}
+		case <-ctx.Done():
+			return nil
+		}
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	for range 10 {
+		endpoints, err := provider.GetEndpoints(ctx)
+		if err != nil || !hasFallbackAddress(endpoints, "192.0.2.53:53") {
+			t.Fatalf("cached local resolver missing: endpoints=%v err=%v", endpoints, err)
+		}
+	}
+	<-refreshStarted
+	if calls.Load() != 2 {
+		t.Fatalf("discover calls=%d, want one startup and one coalesced refresh", calls.Load())
+	}
+	close(release)
+	waitFallbackRefresh(t, provider)
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.servers) != 1 || provider.servers[0] != "192.0.2.54" {
+		t.Fatalf("cached servers=%v, want refreshed resolver", provider.servers)
+	}
+}
+
+func TestWindowsFallbackPreservesCacheWhenRefreshFails(t *testing.T) {
+	var calls atomic.Int32
+	provider := newFallbackDNSProvider("windows", func(context.Context) []string {
+		if calls.Add(1) == 1 {
+			return []string{"192.0.2.53"}
+		}
+		return nil
+	})
+	if _, err := provider.GetEndpoints(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	waitFallbackRefresh(t, provider)
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.servers) != 1 || provider.servers[0] != "192.0.2.53" {
+		t.Fatalf("failed discovery erased cached resolver: %v", provider.servers)
+	}
+}
+
+func TestNonWindowsFallbackDiscoveryRetainsShortBudget(t *testing.T) {
+	var calls int
+	provider := newFallbackDNSProvider("darwin", func(ctx context.Context) []string {
+		calls++
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) > 250*time.Millisecond {
+			t.Error("discovery exceeded recovery budget")
+		}
+		return []string{"192.0.2.53"}
+	})
+	if calls != 0 {
+		t.Fatal("non-Windows provider should not discover during construction")
+	}
+	endpoints, err := provider.GetEndpoints(context.Background())
+	if err != nil || calls != 1 || !hasFallbackAddress(endpoints, "192.0.2.53:53") {
+		t.Fatalf("fallback result=%v err=%v calls=%d", endpoints, err, calls)
+	}
+}
+
+func waitFallbackRefresh(t *testing.T, provider *fallbackDNSProvider) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		provider.mu.Lock()
+		busy := provider.refreshing
+		provider.mu.Unlock()
+		if !busy {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("fallback refresh did not finish")
+}

--- a/internal/runtime/live_doh_test.go
+++ b/internal/runtime/live_doh_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -23,14 +24,14 @@ func TestLiveDoHChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ips, err := resolveBootstrapIPs(hostname)
+	ips, err := resolveBootstrapIPs(context.Background(), hostname)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Logf("bootstrap IPs for %s: %v", hostname, ips)
 
 	ep := &endpoint.DOHEndpoint{Hostname: hostname, Path: path, Bootstrap: ips}
-	mgr := newEndpointManager(endpoint.StaticProvider([]endpoint.Endpoint{ep}), ep)
+	mgr := newEndpointManager(ep, endpoint.StaticProvider([]endpoint.Endpoint{ep}), newFallbackDNSProvider(runtime.GOOS, discoverDNSServers))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/internal/runtime/live_resolver_test.go
+++ b/internal/runtime/live_resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"net"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -30,14 +31,14 @@ func TestLiveResolverServesAndPurges(t *testing.T) {
 	}
 
 	hostname, path := splitDoHBase(base)
-	ips, err := resolveBootstrapIPs(hostname)
+	ips, err := resolveBootstrapIPs(context.Background(), hostname)
 	if err != nil {
 		t.Fatalf("bootstrap resolution failed: %v", err)
 	}
 	t.Logf("bootstrap IPs for %s: %v", hostname, ips)
 
 	ep := &endpoint.DOHEndpoint{Hostname: hostname, Path: path, Bootstrap: ips}
-	mgr := newEndpointManager(endpoint.StaticProvider([]endpoint.Endpoint{ep}), ep)
+	mgr := newEndpointManager(ep, endpoint.StaticProvider([]endpoint.Endpoint{ep}), newFallbackDNSProvider(runtime.GOOS, discoverDNSServers))
 
 	cache, err := lru.NewARC(dnsCacheEntries)
 	if err != nil {
@@ -45,9 +46,9 @@ func TestLiveResolverServesAndPurges(t *testing.T) {
 	}
 
 	// Wired exactly as the proxy wires it.
-	res := retryResolver{inner: &resolver.DNS{
+	res := retryResolver{recover: mgr.Test, inner: &resolver.DNS{
 		DOH:     resolver.DOH{URL: base, Cache: cache},
-		Manager: mgr,
+		Manager: mgr.queries,
 	}}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)

--- a/internal/runtime/recovery_integration_test.go
+++ b/internal/runtime/recovery_integration_test.go
@@ -1,0 +1,226 @@
+package runtime
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/nextdns/nextdns/resolver"
+	"github.com/nextdns/nextdns/resolver/endpoint"
+	"github.com/nextdns/nextdns/resolver/query"
+)
+
+// A real UDP resolver that can become silent without closing its socket.
+// Every socket binds an ephemeral loopback port; system DNS is untouched.
+type recoveryUDPServer struct {
+	ep       *endpoint.DNSEndpoint
+	answers  atomic.Bool
+	requests atomic.Int32
+	received chan struct{}
+}
+
+func newRecoveryUDPServer(t *testing.T, answering bool, lastIPByte byte) *recoveryUDPServer {
+	t.Helper()
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &recoveryUDPServer{
+		ep:       &endpoint.DNSEndpoint{Addr: conn.LocalAddr().String()},
+		received: make(chan struct{}, 64),
+	}
+	s.answers.Store(answering)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 2048)
+		for {
+			n, addr, err := conn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			s.requests.Add(1)
+			select {
+			case s.received <- struct{}{}:
+			default:
+			}
+			if !s.answers.Load() || n < 12 {
+				continue
+			}
+			buf[2], buf[3] = 0x81, 0x80
+			binary.BigEndian.PutUint16(buf[6:8], 1)
+			answer := append(buf[:n:n], 0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 0, 60, 0, 4, 192, 0, 2, lastIPByte)
+			_, _ = conn.WriteTo(answer, addr)
+		}
+	}()
+	t.Cleanup(func() { _ = conn.Close(); <-done })
+	return s
+}
+
+func recoveryQuery() query.Query {
+	return query.Query{
+		ID: 0x1234, Class: query.ClassINET, Type: query.TypeA, Name: "example.org.",
+		Payload: []byte{0x12, 0x34, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'o', 'r', 'g', 0, 0, 1, 0, 1},
+	}
+}
+
+func TestRecoveryIntegrationConcurrentInitialization(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Initialize HTTP transport without making a network request.
+	for range 1000 {
+		ep := &endpoint.DOHEndpoint{Hostname: "localhost", Path: "/dns-query", Bootstrap: []string{"127.0.0.1"}}
+		m := newEndpointManager(ep, endpoint.StaticProvider([]endpoint.Endpoint{ep}))
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = ep.Exchange(ctx, nil, make([]byte, 512))
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = m.queries.Do(ctx, func(endpoint.Endpoint) error { return nil })
+		}()
+		close(start)
+		wg.Wait()
+	}
+}
+
+func TestRecoveryIntegrationSilentPrimaryThenReturnToPreferred(t *testing.T) {
+	primary := newRecoveryUDPServer(t, false, 1)
+	deadFallback := newRecoveryUDPServer(t, false, 2)
+	liveFallback := newRecoveryUDPServer(t, true, 3)
+	m := newEndpointManager(primary.ep,
+		endpoint.StaticProvider([]endpoint.Endpoint{primary.ep}),
+		endpoint.StaticProvider([]endpoint.Endpoint{deadFallback.ep, liveFallback.ep}),
+	)
+	r := retryResolver{inner: &resolver.DNS{Manager: m.queries}, recover: m.Test}
+	buf := make([]byte, 2048)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	start := time.Now()
+	n, info, err := r.Resolve(ctx, recoveryQuery(), buf)
+	if err != nil || n < 16 || buf[n-1] != 3 || info.Transport != "UDP" {
+		t.Fatalf("fallback response: n=%d info=%+v err=%v", n, info, err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("response exceeded total deadline: %v", ctx.Err())
+	}
+	if primary.requests.Load() < 2 || liveFallback.requests.Load() < 2 {
+		t.Fatalf("expected failed primary query/probe and successful fallback probe/query; primary=%d fallback=%d", primary.requests.Load(), liveFallback.requests.Load())
+	}
+	t.Logf("silent primary recovered through responsive second fallback in %v", time.Since(start))
+
+	primary.answers.Store(true)
+	if err := m.Test(ctx); err != nil {
+		t.Fatalf("recovery probe: %v", err)
+	}
+	n, _, err = r.Resolve(ctx, recoveryQuery(), buf)
+	if err != nil || n < 16 || buf[n-1] != 1 {
+		t.Fatalf("preferred resolver did not resume answering: n=%d err=%v", n, err)
+	}
+}
+
+func TestRecoveryIntegrationCacheAndQueryDeadlineDuringProbe(t *testing.T) {
+	primary := newRecoveryUDPServer(t, true, 1)
+	m := newEndpointManager(primary.ep, endpoint.StaticProvider([]endpoint.Endpoint{primary.ep}))
+	cache, err := lru.NewARC(16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := retryResolver{inner: &resolver.DNS{Manager: m.queries, DNS53: resolver.DNS53{Cache: cache}}, recover: m.Test}
+	buf := make([]byte, 2048)
+	if _, _, err := r.Resolve(context.Background(), recoveryQuery(), buf); err != nil {
+		t.Fatal(err)
+	}
+	<-primary.received
+	primary.answers.Store(false)
+	probeDone := make(chan error, 1)
+	probeCtx, cancelProbe := context.WithCancel(context.Background())
+	defer cancelProbe()
+	go func() { probeDone <- m.Test(probeCtx) }()
+	select {
+	case <-primary.received:
+	case <-time.After(time.Second):
+		t.Fatal("health probe did not reach upstream")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	n, info, err := r.Resolve(ctx, recoveryQuery(), buf)
+	if err != nil || !info.FromCache || n < 16 || ctx.Err() != nil {
+		t.Fatalf("probe blocked cached answer: n=%d info=%+v err=%v context=%v", n, info, err, ctx.Err())
+	}
+	cache.Purge()
+	ctx, cancelQuery := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancelQuery()
+	start := time.Now()
+	_, _, err = r.Resolve(ctx, recoveryQuery(), buf)
+	if err == nil {
+		t.Fatal("silent uncached upstream unexpectedly answered")
+	}
+	if elapsed := time.Since(start); elapsed > 400*time.Millisecond {
+		t.Fatalf("query exceeded its deadline behind ongoing probe: %v", elapsed)
+	}
+	select {
+	case <-probeDone:
+		t.Fatal("short query should return while health probe is still running")
+	default:
+	}
+	cancelProbe()
+	<-probeDone
+}
+
+func TestRecoveryIntegrationConcurrentRecoveryCoalescesAndWaitersCancel(t *testing.T) {
+	live := newRecoveryUDPServer(t, true, 1)
+	entered, release := make(chan struct{}), make(chan struct{})
+	var providerCalls atomic.Int32
+	provider := endpoint.ProviderFunc(func(ctx context.Context) ([]endpoint.Endpoint, error) {
+		if providerCalls.Add(1) == 1 {
+			close(entered)
+		}
+		select {
+		case <-release:
+			return []endpoint.Endpoint{live.ep}, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	})
+	m := newEndpointManager(live.ep, provider)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	first := make(chan error, 1)
+	go func() { first <- m.Test(ctx) }()
+	<-entered
+	const waiters = 16
+	results := make(chan error, waiters)
+	for range waiters {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			results <- m.Test(ctx)
+		}()
+	}
+	for range waiters {
+		if err := <-results; !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("waiting recovery ignored cancellation: %v", err)
+		}
+	}
+	if got := providerCalls.Load(); got != 1 {
+		t.Fatalf("concurrent recovery duplicated provider work: calls=%d", got)
+	}
+	close(release)
+	if err := <-first; err != nil {
+		t.Fatalf("cancelled waiters cancelled shared recovery: %v", err)
+	}
+	if got := live.requests.Load(); got != 1 {
+		t.Fatalf("expected one shared network probe, got %d", got)
+	}
+}

--- a/internal/runtime/resolver_retry.go
+++ b/internal/runtime/resolver_retry.go
@@ -2,27 +2,57 @@ package runtime
 
 import (
 	"context"
+	"time"
 
 	"github.com/nextdns/nextdns/resolver"
 	"github.com/nextdns/nextdns/resolver/query"
 )
 
-// retryResolver masks transient upstream failures (dead connections after
-// wake/network change) that the proxy would otherwise surface as SERVFAIL:
-// it retries a failed resolve once, and if the upstream is still unreachable
-// it serves the expired cache entry the inner resolver leaves in buf (see
-// resolver.Resolver contract) instead of failing.
+const queryTimeout = 5 * time.Second
+
+// retryResolver reserves time for recovery and a second attempt within one
+// deadline. An expired cached answer survives even if the fallback has no cache.
 type retryResolver struct {
-	inner resolver.Resolver
+	inner   resolver.Resolver
+	recover func(context.Context) error
 }
 
 func (r retryResolver) Resolve(ctx context.Context, q query.Query, buf []byte) (int, resolver.ResolveInfo, error) {
-	n, i, err := r.inner.Resolve(ctx, q, buf)
-	if err != nil && ctx.Err() == nil {
-		n, i, err = r.inner.Resolve(ctx, q, buf)
+	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
+	defer cancel()
+	deadline, _ := ctx.Deadline()
+	// The resolver contract allows Payload and buf to share memory. Preserve the
+	// query before an expired cached response can overwrite it on the first call.
+	payload := append([]byte(nil), q.Payload...)
+	attempt, cancelAttempt := context.WithTimeout(ctx, min(1500*time.Millisecond, time.Until(deadline)/3))
+	n, info, err := r.inner.Resolve(attempt, q, buf)
+	cancelAttempt()
+	if err == nil {
+		return n, info, nil
 	}
-	if err != nil && n > 0 && i.FromCache {
-		return n, i, nil
+	var stale []byte
+	staleInfo := info
+	if n > 0 && info.FromCache {
+		stale = append([]byte(nil), buf[:n]...)
 	}
-	return n, i, err
+	if ctx.Err() == nil {
+		if r.recover != nil {
+			recovery, cancelRecovery := context.WithTimeout(ctx, min(2*time.Second, time.Until(deadline)/2))
+			_ = r.recover(recovery)
+			cancelRecovery()
+		}
+		if ctx.Err() == nil {
+			q.Payload = payload
+			n, info, err = r.inner.Resolve(ctx, q, buf)
+		}
+	}
+	if err != nil {
+		if n > 0 && info.FromCache {
+			return n, info, nil
+		}
+		if len(stale) > 0 {
+			return copy(buf, stale), staleInfo, nil
+		}
+	}
+	return n, info, err
 }

--- a/internal/runtime/resolver_retry_test.go
+++ b/internal/runtime/resolver_retry_test.go
@@ -4,10 +4,53 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/nextdns/nextdns/resolver"
 	"github.com/nextdns/nextdns/resolver/query"
 )
+
+type contextResolver func(context.Context, query.Query, []byte) (int, resolver.ResolveInfo, error)
+
+func (f contextResolver) Resolve(ctx context.Context, q query.Query, buf []byte) (int, resolver.ResolveInfo, error) {
+	return f(ctx, q, buf)
+}
+
+func TestRetryResolverReservesTimeAfterStalledAttempt(t *testing.T) {
+	calls := 0
+	inner := contextResolver(func(ctx context.Context, _ query.Query, _ []byte) (int, resolver.ResolveInfo, error) {
+		calls++
+		if calls == 1 {
+			<-ctx.Done()
+			return 0, resolver.ResolveInfo{}, ctx.Err()
+		}
+		return 42, resolver.ResolveInfo{}, nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	n, _, err := (retryResolver{inner: inner}).Resolve(ctx, query.Query{}, nil)
+	if err != nil || n != 42 || calls != 2 {
+		t.Fatalf("n=%d calls=%d err=%v; stalled attempt consumed retry budget", n, calls, err)
+	}
+}
+
+func TestRetryResolverPreservesStaleAnswerAcrossFallbackFailure(t *testing.T) {
+	calls := 0
+	inner := contextResolver(func(_ context.Context, _ query.Query, buf []byte) (int, resolver.ResolveInfo, error) {
+		calls++
+		if calls == 1 {
+			copy(buf, []byte("stale"))
+			return 5, resolver.ResolveInfo{FromCache: true}, errors.New("DoH offline")
+		}
+		clear(buf)
+		return 0, resolver.ResolveInfo{}, errors.New("fallback offline")
+	})
+	buf := make([]byte, 10)
+	n, info, err := (retryResolver{inner: inner}).Resolve(context.Background(), query.Query{}, buf)
+	if err != nil || !info.FromCache || string(buf[:n]) != "stale" {
+		t.Fatalf("lost stale answer: n=%d cache=%v err=%v", n, info.FromCache, err)
+	}
+}
 
 type fakeResolver struct {
 	calls   int
@@ -41,7 +84,7 @@ func TestRetryResolverServesStaleCacheOnPersistentError(t *testing.T) {
 	}
 	inner := &fakeResolver{results: []func() (int, resolver.ResolveInfo, error){fail, fail}}
 
-	n, i, err := retryResolver{inner: inner}.Resolve(context.Background(), query.Query{}, nil)
+	n, i, err := retryResolver{inner: inner}.Resolve(context.Background(), query.Query{}, make([]byte, 100))
 	if err != nil {
 		t.Fatalf("expected stale answer instead of error, got %v", err)
 	}

--- a/internal/runtime/runtime_run.go
+++ b/internal/runtime/runtime_run.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"net"
 	"os"
+	"runtime"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/nextdns/nextdns/host/service"
@@ -54,7 +54,7 @@ func Run(version, profileID, overrideServer, overrideAPIServer, accountToken str
 	log.Printf("API server: %s", cfg.APIServer)
 
 	var bootstrapIPs []string
-	if ips, err := resolveBootstrapIPs(dohHostname); err != nil {
+	if ips, err := resolveBootstrapIPs(context.Background(), dohHostname); err != nil {
 		log.Printf("Warning: bootstrap resolution failed: %v", err)
 	} else {
 		bootstrapIPs = ips
@@ -74,9 +74,9 @@ func Run(version, profileID, overrideServer, overrideAPIServer, accountToken str
 	var dohEp atomic.Pointer[endpoint.DOHEndpoint]
 	dohEp.Store(dohEndpoint)
 
-	mgr := newEndpointManager(endpoint.ProviderFunc(func(context.Context) ([]endpoint.Endpoint, error) {
+	mgr := newEndpointManager(dohEndpoint, endpoint.ProviderFunc(func(context.Context) ([]endpoint.Endpoint, error) {
 		return []endpoint.Endpoint{dohEp.Load()}, nil
-	}), dohEndpoint)
+	}), newFallbackDNSProvider(runtime.GOOS, discoverDNSServers))
 
 	// Client-side DNS response cache. Avoids upstream round-trips for
 	// frequently queried domains. Purged on rule updates via SSE so that
@@ -93,7 +93,7 @@ func Run(version, profileID, overrideServer, overrideAPIServer, accountToken str
 
 	p := proxy.Proxy{
 		Addrs: listenAddrs,
-		Upstream: retryResolver{inner: &resolver.DNS{
+		Upstream: retryResolver{recover: mgr.Test, inner: &resolver.DNS{
 			DOH: resolver.DOH{
 				URL:   dohURL,
 				Cache: dnsCache,
@@ -101,7 +101,7 @@ func Run(version, profileID, overrideServer, overrideAPIServer, accountToken str
 					return dohURL, cfg.ProfileID
 				},
 			},
-			Manager: mgr,
+			Manager: mgr.queries,
 		}},
 		QueryLog: func(qi proxy.QueryInfo) {
 			switch {
@@ -113,7 +113,7 @@ func Run(version, profileID, overrideServer, overrideAPIServer, accountToken str
 				log.Printf("%-5s %s %s", qi.Protocol, qi.UpstreamTransport, qi.Name)
 			}
 		},
-		Timeout:             5 * time.Second,
+		Timeout:             queryTimeout,
 		MaxInflightRequests: 256,
 		InfoLog:             func(msg string) { log.Println(msg) },
 		ErrorLog:            func(err error) { log.Printf("ERROR: %v", err) },
@@ -130,6 +130,7 @@ func Run(version, profileID, overrideServer, overrideAPIServer, accountToken str
 		refresher.refresh(ctx)
 	}
 	onReady = append(onReady, func(ctx context.Context) { manageSystemDNS(ctx, onNetworkChange) })
+	onReady = append(onReady, mgr.watch)
 
 	if service.CurrentRunMode() == service.RunModeService {
 		onInit = append(onInit, func(ctx context.Context) {


### PR DESCRIPTION
When the DoH upstream stalls, endpoint health checks can block unrelated DNS queries and leave too little time to retry. Keep network probes outside the query lock, select a responding fallback, and reserve recovery time within one query deadline while preserving stale cached answers.

Bootstrap lookups now run concurrently under a bounded deadline without resolving through the local proxy. Windows network-DNS discovery is cached outside recovery requests, and endpoint metadata is initialized before concurrent transport use.

Validation: full Go race suite, vet, formatting, ShellCheck, and vulnerability scan pass locally. Controlled failure recovered through the second fallback in 2.34 seconds; live DoH/cache/purge checks passed, with one transient probe timeout before successful repeats. Native CI must pass before release. The original office-network incident has not been reproduced.
